### PR TITLE
feat: support png/jpg for canvas layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,5 +96,10 @@
     "docs": "typedoc src/index.ts",
     "prepare": "yarn run build"
   },
-  "packageManager": "yarn@3.2.3"
+  "packageManager": "yarn@3.2.3",
+  "dependenciesMeta": {
+    "cytoscape@3.23.0": {
+      "unplugged": true
+    }
+  }
 }

--- a/samples/animatedEdge.html
+++ b/samples/animatedEdge.html
@@ -11,6 +11,8 @@
     </style>
   </head>
   <body>
+    <button id="png">PNG</button>
+    <a id="url" download="file.png"></a>
     <div id="app"></div>
     <script src="https://cdn.jsdelivr.net/npm/cytoscape"></script>
     <script src="../build/index.umd.js"></script>

--- a/samples/animatedEdges.ts
+++ b/samples/animatedEdges.ts
@@ -109,16 +109,14 @@ namespace AnimatedEdges {
     requestAnimationFrame(update);
 
     document.getElementById('png')?.addEventListener('click', () => {
-      layers
-        .png({
-          output: 'blob-promise',
-        })
-        .then((r) => {
-          const url = URL.createObjectURL(r);
-          const a = document.getElementById('url') as HTMLAnchorElement;
-          a.href = url;
-          a.click();
-        });
+      cy.png({
+        output: 'blob-promise',
+      }).then((r) => {
+        const url = URL.createObjectURL(r);
+        const a = document.getElementById('url') as HTMLAnchorElement;
+        a.href = url;
+        a.click();
+      });
     });
   }
 

--- a/samples/animatedEdges.ts
+++ b/samples/animatedEdges.ts
@@ -42,6 +42,7 @@ namespace AnimatedEdges {
     return vSet;
   }
   const layers = CytoscapeLayers.layers(cy);
+
   const layer = layers.nodeLayer.insertBefore('canvas');
 
   function animateEdges(options: {
@@ -106,6 +107,19 @@ namespace AnimatedEdges {
       }
     );
     requestAnimationFrame(update);
+
+    document.getElementById('png')?.addEventListener('click', () => {
+      layers
+        .png({
+          output: 'blob-promise',
+        })
+        .then((r) => {
+          const url = URL.createObjectURL(r);
+          const a = document.getElementById('url') as HTMLAnchorElement;
+          a.href = url;
+          a.click();
+        });
+    });
   }
 
   cy.one('ready', () => {

--- a/samples/annotations.html
+++ b/samples/annotations.html
@@ -11,6 +11,8 @@
     </style>
   </head>
   <body>
+    <button id="png">PNG</button>
+    <a id="url" download="file.png"></a>
     <div id="app"></div>
     <script src="https://cdn.jsdelivr.net/npm/cytoscape"></script>
     <script src="../build/index.umd.js"></script>

--- a/samples/annotations.ts
+++ b/samples/annotations.ts
@@ -60,4 +60,18 @@ namespace Annotations {
   });
 
   console.log(layers);
+
+  document.getElementById('png')?.addEventListener('click', () => {
+    layers
+      .png({
+        output: 'blob-promise',
+        ignoreUnsupportedLayerOrder: true,
+      })
+      .then((r) => {
+        const url = URL.createObjectURL(r);
+        const a = document.getElementById('url') as HTMLAnchorElement;
+        a.href = url;
+        a.click();
+      });
+  });
 }

--- a/src/LayersPlugin.ts
+++ b/src/LayersPlugin.ts
@@ -45,6 +45,8 @@ export class LayerExportException extends Error {}
 export default class LayersPlugin {
   readonly cy: cy.Core;
 
+  private bak: Record<string, any> = {};
+
   readonly nodeLayer: ICytoscapeNodeLayer;
 
   readonly dragLayer: ICytoscapeDragLayer;
@@ -116,6 +118,15 @@ export default class LayersPlugin {
     cy.on('resize', this.resize);
     cy.on('destroy', this.destroy);
 
+    this.bak = {
+      png: cy.png,
+      jpg: cy.jpg,
+      jpeg: cy.jpeg,
+    };
+    cy.png = this.png.bind(this);
+    cy.jpg = this.jpg.bind(this);
+    cy.jpeg = this.jpeg.bind(this);
+
     this.viewport = {
       width: this.cy.width(),
       height: this.cy.height(),
@@ -177,6 +188,12 @@ export default class LayersPlugin {
     this.cy.off('viewport', this.zoomed);
     this.cy.off('resize', this.resize);
     this.cy.scratch('_layers', undefined);
+
+    this.cy.png = this.bak.png;
+    this.cy.jpg = this.bak.jpg;
+    this.cy.jpeg = this.bak.jpeg;
+
+    this.bak = {};
   };
 
   private readonly zoomed = () => {

--- a/src/LayersPlugin.ts
+++ b/src/LayersPlugin.ts
@@ -26,7 +26,6 @@ import {
   ISVGLayerOptions,
   ICanvasLayerOptions,
   IPoint,
-  CytoscapeBaseLayer,
 } from './layers';
 import type { ILayerAdapter } from './layers/ABaseLayer';
 import { renderPerEdge, renderPerNode } from './elements';
@@ -337,11 +336,11 @@ export default class LayersPlugin {
     const before = layers
       .slice(0, nodeIndex)
       .reverse()
-      .filter((d) => d.supportsRender && d !== this.dragLayer && d !== this.selectBoxLayer);
+      .filter((d) => d.supportsRender() && d !== this.dragLayer && d !== this.selectBoxLayer);
 
     const after = layers
       .slice(nodeIndex + 1)
-      .filter((d) => d.supportsRender && d !== this.dragLayer && d !== this.selectBoxLayer);
+      .filter((d) => d.supportsRender() && d !== this.dragLayer && d !== this.selectBoxLayer);
 
     const scale = options.scale ?? 1;
 

--- a/src/copied.ts
+++ b/src/copied.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2016-2022, The Cytoscape Consortium.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import type cy from 'cytoscape';
+
+function b64ToBlob(b64: string, mimeType: string): Blob {
+  const bytes = atob(b64);
+  const buff = new ArrayBuffer(bytes.length);
+  const buffUint8 = new Uint8Array(buff);
+
+  for (let i = 0; i < bytes.length; i++) {
+    buffUint8[i] = bytes.charCodeAt(i);
+  }
+
+  return new Blob([buff], {
+    type: mimeType,
+  });
+}
+
+function b64UriToB64(b64uri: string): string {
+  const i = b64uri.indexOf(',');
+  return b64uri.substring(i + 1);
+}
+
+export function output(
+  options: cy.ExportJpgStringOptions | cy.ExportJpgBlobOptions | cy.ExportJpgBlobPromiseOptions,
+  canvas: HTMLCanvasElement,
+  mimeType: string
+) {
+  const getB64Uri = function getB64Uri() {
+    return canvas.toDataURL(mimeType, options.quality);
+  };
+
+  switch (options.output) {
+    case 'blob-promise':
+      return new Promise((resolve, reject) => {
+        try {
+          canvas.toBlob(
+            function (blob) {
+              if (blob != null) {
+                resolve(blob);
+              } else {
+                reject(new Error('`canvas.toBlob()` sent a null value in its callback'));
+              }
+            },
+            mimeType,
+            options.quality
+          );
+        } catch (err) {
+          reject(err);
+        }
+      });
+
+    case 'blob':
+      return b64ToBlob(b64UriToB64(getB64Uri()), mimeType);
+
+    case 'base64':
+      return b64UriToB64(getB64Uri());
+
+    case 'base64uri':
+    default:
+      return getB64Uri();
+  }
+}

--- a/src/layers/ABaseLayer.ts
+++ b/src/layers/ABaseLayer.ts
@@ -35,7 +35,7 @@ export abstract class ABaseLayer implements IMoveAbleLayer {
     return this.adapter.inVisibleBounds(p);
   }
 
-  get supportsRender() {
+  supportsRender() {
     return false;
   }
 

--- a/src/layers/ABaseLayer.ts
+++ b/src/layers/ABaseLayer.ts
@@ -7,6 +7,7 @@ import type {
   IHTMLStaticLayer,
   ISVGStaticLayer,
   ICanvasStaticLayer,
+  IRenderHint,
 } from './interfaces';
 import type cy from 'cytoscape';
 import type { ICanvasLayerOptions, ISVGLayerOptions, IHTMLLayerOptions } from './public';
@@ -32,6 +33,14 @@ export abstract class ABaseLayer implements IMoveAbleLayer {
 
   inVisibleBounds(p: { x: number; y: number } | cy.BoundingBox12) {
     return this.adapter.inVisibleBounds(p);
+  }
+
+  get supportsRender() {
+    return false;
+  }
+
+  renderInto(_ctx: CanvasRenderingContext2D, _hint: IRenderHint): void {
+    // dummy
   }
 
   get updateOnRender() {

--- a/src/layers/CanvasLayer.ts
+++ b/src/layers/CanvasLayer.ts
@@ -92,6 +92,10 @@ export class CanvasBaseLayer extends ABaseLayer implements ILayerImpl {
     ctx.restore();
   }
 
+  supportsRender(): boolean {
+    return true;
+  }
+
   renderInto(ctx: CanvasRenderingContext2D, hint: IRenderHint): void {
     this.drawImpl(ctx, hint.scale);
   }

--- a/src/layers/CanvasLayer.ts
+++ b/src/layers/CanvasLayer.ts
@@ -1,4 +1,11 @@
-import type { ICanvasLayer, ILayerElement, ILayerImpl, IRenderFunction, ICanvasStaticLayer } from './interfaces';
+import type {
+  ICanvasLayer,
+  ILayerElement,
+  ILayerImpl,
+  IRenderFunction,
+  ICanvasStaticLayer,
+  IRenderHint,
+} from './interfaces';
 import { layerStyle, stopClicks } from './utils';
 import { ABaseLayer, ILayerAdapter } from './ABaseLayer';
 import type { ICanvasLayerOptions } from './public';
@@ -68,17 +75,25 @@ export class CanvasBaseLayer extends ABaseLayer implements ILayerImpl {
 
   draw() {
     this.clear();
-    this.ctx.save();
-    this.ctx.resetTransform();
-    this.ctx.scale(this.pixelRatio, this.pixelRatio);
-    this.ctx.translate(this.transform.tx, this.transform.ty);
-    this.ctx.scale(this.transform.zoom, this.transform.zoom);
+    this.drawImpl(this.ctx);
+  }
+
+  private drawImpl(ctx: CanvasRenderingContext2D, scale = 1) {
+    ctx.save();
+    ctx.resetTransform();
+    ctx.scale(this.pixelRatio, this.pixelRatio);
+    ctx.translate(this.transform.tx * scale, this.transform.ty * scale);
+    ctx.scale(this.transform.zoom * scale, this.transform.zoom * scale);
 
     for (const r of this.callbacks) {
-      r(this.ctx);
+      r(ctx);
     }
 
-    this.ctx.restore();
+    ctx.restore();
+  }
+
+  renderInto(ctx: CanvasRenderingContext2D, hint: IRenderHint): void {
+    this.drawImpl(ctx, hint.scale);
   }
 
   resize(width: number, height: number) {

--- a/src/layers/CytoscapeLayer.ts
+++ b/src/layers/CytoscapeLayer.ts
@@ -35,7 +35,7 @@ export class CytoscapeBaseLayer extends ABaseLayer implements ILayerImpl {
     // dummy
   }
 
-  get supportsRender(): boolean {
+  supportsRender(): boolean {
     return true;
   }
 }

--- a/src/layers/CytoscapeLayer.ts
+++ b/src/layers/CytoscapeLayer.ts
@@ -34,6 +34,10 @@ export class CytoscapeBaseLayer extends ABaseLayer implements ILayerImpl {
   remove() {
     // dummy
   }
+
+  get supportsRender(): boolean {
+    return true;
+  }
 }
 
 export class CytoscapeNodeLayer extends CytoscapeBaseLayer implements ICytoscapeNodeLayer {

--- a/src/layers/HTMLLayer.ts
+++ b/src/layers/HTMLLayer.ts
@@ -31,6 +31,10 @@ export class HTMLLayer extends ADOMBaseLayer<HTMLElement> implements IHTMLLayer,
       this.update();
     }
   }
+
+  renderInto(): boolean {
+    return false;
+  }
 }
 
 export class HTMLStaticLayer extends ADOMBaseLayer<HTMLElement> implements IHTMLStaticLayer, ILayerImpl {

--- a/src/layers/HTMLLayer.ts
+++ b/src/layers/HTMLLayer.ts
@@ -32,8 +32,8 @@ export class HTMLLayer extends ADOMBaseLayer<HTMLElement> implements IHTMLLayer,
     }
   }
 
-  renderInto(): boolean {
-    return false;
+  supportsRender(): boolean {
+    return this.node.childElementCount === 0;
   }
 }
 

--- a/src/layers/SVGLayer.ts
+++ b/src/layers/SVGLayer.ts
@@ -30,6 +30,10 @@ export class SVGLayer extends ADOMBaseLayer<SVGElement> implements ISVGLayer, IL
       this.update();
     }
   }
+
+  supportsRender(): boolean {
+    return this.node.childElementCount === 0;
+  }
 }
 
 export class SVGStaticLayer extends ADOMBaseLayer<SVGElement> implements ISVGStaticLayer, ILayerImpl {

--- a/src/layers/interfaces.ts
+++ b/src/layers/interfaces.ts
@@ -19,6 +19,6 @@ export interface ILayerImpl {
   remove(): void;
   setViewport(tx: number, ty: number, zoom: number): void;
 
-  readonly supportsRender: boolean;
+  supportsRender(): boolean;
   renderInto(ctx: CanvasRenderingContext2D, hint: IRenderHint): void;
 }

--- a/src/layers/interfaces.ts
+++ b/src/layers/interfaces.ts
@@ -6,9 +6,19 @@ export interface ILayerElement {
   __cy_layer: ILayer & ILayerImpl;
 }
 
+export interface IRenderHint {
+  scale: number;
+  width: number;
+  height: number;
+  full: boolean;
+}
+
 export interface ILayerImpl {
   readonly root: HTMLElement | SVGElement;
   resize(width: number, height: number): void;
   remove(): void;
   setViewport(tx: number, ty: number, zoom: number): void;
+
+  readonly supportsRender: boolean;
+  renderInto(ctx: CanvasRenderingContext2D, hint: IRenderHint): void;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3449,6 +3449,9 @@ __metadata:
     typescript: ^4.8.3
   peerDependencies:
     cytoscape: ^3.23.0
+  dependenciesMeta:
+    cytoscape@3.23.0:
+      unplugged: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
support `layers.png` and `layers.jpg` that extend dumping the cytoscape layers with the canvas layers. 

Other layers (html, svg) are currently not supported. 